### PR TITLE
Updated useIsTouchDevice to work when rendering with SSR

### DIFF
--- a/.test/setupTests.ts
+++ b/.test/setupTests.ts
@@ -1,18 +1,21 @@
 /* eslint-disable prettier/prettier */
 import '@testing-library/jest-dom/extend-expect';
-import MutationObserver from 'mutation-observer';
 
-// Global MutationObserver Mocks
-window.MutationObserver = MutationObserver;
+// React SSR when environment is not js-dom
+if (global.window !== undefined) {
 
-// Global Test Environment Mocks
-window.matchMedia = jest.fn((query: string): MediaQueryList => ({
-  media: query,
-  onchange: null,
-  matches: false,
-  addListener: jest.fn(),
-  dispatchEvent: jest.fn(),
-  removeListener: jest.fn(),
-  addEventListener: jest.fn(),
-  removeEventListener: jest.fn()
-}));
+  // Global MutationObserver Mocks
+  window.MutationObserver = require('mutation-observer');
+
+  // Global Test Environment Mocks
+  window.matchMedia = jest.fn((query: string): MediaQueryList => ({
+    media: query,
+    onchange: null,
+    matches: false,
+    addListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+  }));
+}

--- a/__tests__/ReactSSR.test.tsx
+++ b/__tests__/ReactSSR.test.tsx
@@ -1,0 +1,13 @@
+/**
+ * @jest-environment node
+ */
+
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { Select } from '../src';
+
+test('select element can be rendered using react-dom/server', () => {
+
+  expect(() => renderToString(<Select />)).not.toThrow();
+
+});

--- a/src/hooks/useIsTouchDevice.ts
+++ b/src/hooks/useIsTouchDevice.ts
@@ -8,6 +8,12 @@ export const useIsTouchDevice = (): boolean => {
   const isTouchDevice = useRef<boolean | null>(null);
 
   if (isTouchDevice.current === null) {
+    // Check for SSR where navigator and window may not be defined.
+    if (navigator === undefined || window === undefined) {
+      isTouchDevice.current = false;
+      return isTouchDevice.current;
+    }
+
     isTouchDevice.current = ('ontouchstart' in window || !!navigator.maxTouchPoints);
     return isTouchDevice.current;
   }

--- a/src/hooks/useIsTouchDevice.ts
+++ b/src/hooks/useIsTouchDevice.ts
@@ -9,7 +9,8 @@ export const useIsTouchDevice = (): boolean => {
 
   if (isTouchDevice.current === null) {
     // Check for SSR where navigator and window may not be defined.
-    if (navigator === undefined || window === undefined) {
+    // tslint:disable-next-line:no-typeof-undefined
+    if (typeof navigator === 'undefined' || typeof window === 'undefined') {
       isTouchDevice.current = false;
       return isTouchDevice.current;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,6 +87,8 @@ function smoothScrollTo(
  * Determines if the current browser is IE or Edge (standard/chromium).
  */
 export const isEdgeOrIE = (): boolean => IE_EDGE_BROWSER_REGEXP.test(navigator.userAgent);
+// tslint:disable-next-line:no-typeof-undefined
+export const isEdgeOrIE = (): boolean => typeof navigator !== 'undefined' && IE_EDGE_BROWSER_REGEXP.test(navigator.userAgent);
 
 /**
  * Tests object for type of array with a length of at least 1.


### PR DESCRIPTION
Server side rendering causes an error when rendering a component using this hook when it looks for `navigator`. Added checks for `navigator` and `window` to avoid the look up.