### PR TITLE
Add renderControlLabel prop

### DIFF
--- a/__stories__/helpers/constants/options-data.ts
+++ b/__stories__/helpers/constants/options-data.ts
@@ -1,10 +1,10 @@
 import type { CityOption, PackageOption } from '../../types';
 
 export const PACKAGE_OPTIONS: PackageOption[] = [
-  { id: 1, name: 'react' },
+  { id: 1, name: 'react', description: 'React is a JavaScript library for creating user interfaces'},
   { id: 2, name: 'react-dom' },
   { id: 3, name: 'reactstrap' },
-  { id: 4, name: 'react-scripts' },
+  { id: 4, name: 'react-scripts', description: 'Configuration and scripts for Create React App.' },
   { id: 5, name: 'react-window' }
 ];
 

--- a/__stories__/helpers/styled/index.ts
+++ b/__stories__/helpers/styled/index.ts
@@ -387,10 +387,24 @@ export const OptionContainer = styled.div`
   flex-direction: row;
 `;
 
+export const OptionContent = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
 export const OptionName = styled.span`
   color: #515151;
   font-size: 1em;
   font-weight: 600;
+  margin-left: 1px;
+  margin-bottom: 1.5px;
+`;
+
+export const OptionDescription = styled.span`
+  color: #515151;
+  font-size: 1em;
+  font-weight: 300;
   margin-left: 1px;
   margin-bottom: 1.5px;
 `;

--- a/__stories__/index.stories.tsx
+++ b/__stories__/index.stories.tsx
@@ -38,7 +38,9 @@ import {
   CardBody,
   OtherSpan,
   OptionContainer,
+  OptionContent,
   OptionName,
+  OptionDescription,
   ReactSvg,
   ChevronDownSvg,
   MenuPortalElement,
@@ -807,6 +809,25 @@ export const Advanced = () => {
           <path {...REACT_SVG_PATH_PROPS} />
           <circle {...REACT_SVG_CIRCLE_PROPS} />
         </ReactSvg>
+        <OptionContent>
+          <OptionName>{option.name}</OptionName>
+          {option.description && <OptionDescription>{option.description}</OptionDescription>}
+        </OptionContent>
+      </OptionContainer>
+    ),
+    [getIsOptionDisabled]
+  );
+
+  const renderControlLabel = useCallback(
+    (option: PackageOption): ReactNode => (
+      <OptionContainer>
+        <ReactSvg
+          {...REACT_SVG_PROPS}
+          isDisabled={getIsOptionDisabled(option)}
+        >
+          <path {...REACT_SVG_PATH_PROPS} />
+          <circle {...REACT_SVG_CIRCLE_PROPS} />
+        </ReactSvg>
         <OptionName>{option.name}</OptionName>
       </OptionContainer>
     ),
@@ -875,7 +896,9 @@ export const Advanced = () => {
               themeConfig={THEME_CONFIG}
               caretIcon={customCaretIcon}
               getOptionValue={getOptionValue}
+              menuItemSize={70}
               renderOptionLabel={renderOptionLabel}
+              renderControlLabel={renderControlLabel}
               getIsOptionDisabled={getIsOptionDisabled}
             />
           </SelectContainer>

--- a/__stories__/types/index.d.ts
+++ b/__stories__/types/index.d.ts
@@ -14,4 +14,5 @@ export type CityOption = Readonly<{
 export type PackageOption = Readonly<{
   id: number;
   name: string;
+  description?: string;
 }>;

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -152,6 +152,7 @@ export type SelectProps = Readonly<{
   onInputBlur?: FocusEventHandler<HTMLInputElement>;
   onInputFocus?: FocusEventHandler<HTMLInputElement>;
   renderOptionLabel?: (data: OptionData) => ReactNode;
+  renderControlLabel?: (data: OptionData) => ReactNode;
   getIsOptionDisabled?: (data: OptionData) => boolean;
   getFilterOptionString?: (option: MenuOption) => string;
   renderMultiOptions?: (params: MultiParams) => ReactNode;
@@ -261,6 +262,7 @@ const Select = forwardRef<SelectRef, SelectProps>((
     blurInputOnSelect,
     menuItemDirection,
     renderOptionLabel,
+    renderControlLabel,
     renderMultiOptions,
     menuScrollDuration,
     filterIgnoreAccents,
@@ -313,6 +315,7 @@ const Select = forwardRef<SelectRef, SelectProps>((
   const getOptionLabelFn = useMemo<OptionLabelCallback>(() => getOptionLabel || GET_OPTION_LABEL_DEFAULT, [getOptionLabel]);
   const getOptionValueFn = useMemo<OptionValueCallback>(() => getOptionValue || GET_OPTION_VALUE_DEFAULT, [getOptionValue]);
   const renderOptionLabelFn = useMemo<RenderLabelCallback>(() => renderOptionLabel || getOptionLabelFn, [renderOptionLabel, getOptionLabelFn]);
+  const renderControlLabelFn = useMemo<RenderLabelCallback>(() => renderControlLabel || renderOptionLabelFn, [renderControlLabel, renderOptionLabelFn]);
 
   // Custom hook abstraction that debounces search input value (opt-in)
   const debouncedInputValue = useDebounce<string>(inputValue, inputDelay);
@@ -764,7 +767,7 @@ const Select = forwardRef<SelectRef, SelectProps>((
               selectedOption={selectedOption}
               focusedMultiValue={focusedMultiValue}
               renderMultiOptions={renderMultiOptions}
-              renderOptionLabel={renderOptionLabelFn}
+              renderOptionLabel={renderControlLabelFn}
               removeSelectedOption={removeSelectedOption}
             />
             <AutosizeInput


### PR DESCRIPTION
See issue: https://github.com/based-ghost/react-functional-select/issues/25

This PR adds the ability to render menu options and the selected option in the control differently.

Multi select already provided this ability via `renderMultiOptions`, I also needed this behaviour for a single select.  I wasn't sure whether to name the prop in a similar fashion to `renderMultiOptions` or `renderOptionLabel` and went for the latter - I'm definitely open to naming suggestions 👍 

![Screen Shot 2021-04-26 at 3 51 29 PM](https://user-images.githubusercontent.com/5375799/116141892-460df080-a6a7-11eb-9cc5-01ac0d4e114e.png)
